### PR TITLE
feat: add support for dgraph connection strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project
 adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v24.X.X] - YYYY-MM-DD
+
+**Added**
+
+- Add new pydgraph.Open function to support Dgraph Connection Strings
+
 ## [v24.1.0] - 2024-11-29
 
 **Added**

--- a/examples/simple/simple.py
+++ b/examples/simple/simple.py
@@ -5,16 +5,6 @@ import json
 import pydgraph
 
 
-# Create a client stub.
-def create_client_stub():
-    return pydgraph.DgraphClientStub("localhost:9080")
-
-
-# Create a client.
-def create_client(client_stub):
-    return pydgraph.DgraphClient(client_stub)
-
-
 # Drop All - discard all data and start from a clean slate.
 def drop_all(client):
     return client.alter(pydgraph.Operation(drop_all=True))
@@ -174,8 +164,7 @@ def query_bob(client):
 
 
 def main():
-    client_stub = create_client_stub()
-    client = create_client(client_stub)
+    client = pydgraph.open("dgraph://localhost:9080")
     drop_all(client)
     set_schema(client)
     create_data(client)
@@ -185,8 +174,8 @@ def main():
     query_alice(client)  # query for Alice
     query_bob(client)  # query for Bob
 
-    # Close the client stub.
-    client_stub.close()
+    # Close the client.
+    client.close()
 
 
 if __name__ == "__main__":

--- a/pydgraph/client.py
+++ b/pydgraph/client.py
@@ -174,7 +174,7 @@ class DgraphClient(object):
             client.close()
 
 
-def Open(connection_string: str) -> DgraphClient:
+def open(connection_string: str) -> DgraphClient:
     """Open a new Dgraph client. Use client.close() to close the client.
 
     Args:

--- a/scripts/local-test.sh
+++ b/scripts/local-test.sh
@@ -43,7 +43,7 @@ alphaGrpcPort=$(DockerCompose port alpha1 9080 | awk -F: '{print $2}')
 popd || exit
 export TEST_SERVER_ADDR="localhost:${alphaGrpcPort}"
 echo "Using TEST_SERVER_ADDR=${TEST_SERVER_ADDR}"
-if [ $# -eq 0 ]; then
+if [[ $# -eq 0 ]]; then
 	# No arguments provided, run all tests
 	pytest
 else

--- a/scripts/local-test.sh
+++ b/scripts/local-test.sh
@@ -43,7 +43,13 @@ alphaGrpcPort=$(DockerCompose port alpha1 9080 | awk -F: '{print $2}')
 popd || exit
 export TEST_SERVER_ADDR="localhost:${alphaGrpcPort}"
 echo "Using TEST_SERVER_ADDR=${TEST_SERVER_ADDR}"
-pytest
+if [ $# -eq 0 ]; then
+	# No arguments provided, run all tests
+	pytest
+else
+	# Run specific tests passed as arguments
+	pytest "$@"
+fi
 tests_failed="$?"
 stopCluster
 popd || exit

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,0 +1,83 @@
+import json
+import os
+import unittest
+
+import pytest
+
+from pydgraph import open
+
+
+class TestOpen(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Get connection details from environment or use defaults
+        host = os.environ.get("TEST_SERVER_ADDR", "localhost")
+        host, port = host.split(":")
+        cls.dgraph_host = host
+        cls.dgraph_port = port
+        cls.username = os.environ.get("DGRAPH_USERNAME", "groot")
+        cls.password = os.environ.get("DGRAPH_PASSWORD", "password")
+
+        # Base URL for tests
+        cls.base_url = f"dgraph://{cls.dgraph_host}:{cls.dgraph_port}"
+
+    def test_connection_with_auth(self):
+        """Test connection with username and password."""
+        if not self.username or not self.password:
+            self.skipTest("Username and password not configured")
+
+        url = f"dgraph://{self.username}:{self.password}@{self.dgraph_host}:{self.dgraph_port}"
+        print("URL", url)
+        client = open(url)
+
+        # Verify connection works with credentials
+        query = """
+        {
+            me(func: uid(1)) {
+                uid
+            }
+        }
+        """
+        response = client.txn(read_only=True).query(query)
+        self.assertIsNotNone(response)
+        parsed_json = json.loads(response.json)
+        self.assertEqual(parsed_json["me"][0]["uid"], "0x1")
+
+        client.close()
+
+    def test_invalid_scheme(self):
+        """Test that invalid scheme raises ValueError."""
+        invalid_url = f"http://{self.dgraph_host}:{self.dgraph_port}"
+        with pytest.raises(ValueError, match="scheme must be 'dgraph'"):
+            open(invalid_url)
+
+    def test_missing_hostname(self):
+        """Test that missing hostname raises ValueError."""
+        with pytest.raises(ValueError, match="hostname required"):
+            open(f"dgraph://:{self.dgraph_port}")
+
+    def test_missing_port(self):
+        """Test that missing port raises ValueError."""
+        with pytest.raises(ValueError, match="port required"):
+            open(f"dgraph://{self.dgraph_host}")
+
+    def test_username_without_password(self):
+        """Test that username without password raises ValueError."""
+        with pytest.raises(
+            ValueError, match="password required when username is provided"
+        ):
+            open(f"dgraph://{self.username}@{self.dgraph_host}:{self.dgraph_port}")
+
+    def test_invalid_sslmode(self):
+        """Test that invalid sslmode raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid sslmode"):
+            open(f"dgraph://{self.dgraph_host}:{self.dgraph_port}?sslmode=invalid")
+
+    def test_unsupported_require_sslmode(self):
+        """Test that sslmode=require raises appropriate error."""
+        with pytest.raises(ValueError, match="sslmode=require is not supported"):
+            open(f"dgraph://{self.dgraph_host}:{self.dgraph_port}?sslmode=require")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -27,7 +27,6 @@ class TestOpen(unittest.TestCase):
             self.skipTest("Username and password not configured")
 
         url = f"dgraph://{self.username}:{self.password}@{self.dgraph_host}:{self.dgraph_port}"
-        print("URL", url)
         client = open(url)
 
         # Verify connection works with credentials


### PR DESCRIPTION
This PR adds support to open gRPC endpoints using "connection strings", specifically the `pydgraph.open()` function.

<h2><code>dgraph://{username:password@}host:port?args</code></h2>
<p><code>username</code> and <code>password</code> are optional. If username is provided, a password must also be present. If supplied, these credentials are used to log into the cluster thru the ACL mechanism.</p>
<p>Valid args:</p>

Arg | Value | Description
-- | -- | --
apikey | \<key\> | This is a Dgraph Cloud API key
bearertoken | \<access token\> | An access token
sslmode | disable | The default. Do not connect via TLS
  | require | This is not supported in pydgraph
  | verify-ca | Use TLS and verify the certificate found

The `sslmode=require` pair is not supported and will throw an Exception if used. Python grpc does not support traffic over TLS that does not fully verify the certificate and domain. Developers should use the existing stub/client initialization steps for self-signed certs as demonstrated in `/examples/tls/tls_example.py`.

This PR also adds a `close` method to the DgraphClient class.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable

