### PR TITLE
chore: force the python version when building and running CD

### DIFF
--- a/.github/workflows/cd-pydgraph.yml
+++ b/.github/workflows/cd-pydgraph.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version-file: pyproject.toml
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
**Description**

This PR fixes the python version to 3.12 for deployment. 3.13 creates incompatible protobuf files.
